### PR TITLE
Added graph_features module to generate graph features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## Latest version 3.2.5
+## Latest version 3.2.6
 
 | Release  | Feature link to discussion | State |
 | -------- | -------------------------- | ----- |
+| 3.2.6 | Adds GraphFeatures, also dependencies and description to pyproject.toml | READY |
 | 3.2.5 | Fixes Moebius utf-8 issue, adds create_tutorials(), <br>adds generate_color_palette(), improves Moebius example, <br>adds python 3.13 support. | READY |
 | 3.2.4 | Implements Moebius as anywidget for modern Jupyterlab | READY |
 | 3.2.3 | Fixes Moebius in Google Colab and update docs | READY |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Release  | Feature link to discussion | State |
 | -------- | -------------------------- | ----- |
-| 3.2.6 | Adds GraphFeatures, also dependencies and description to pyproject.toml | READY |
+| 3.2.6 | Adds GraphFeatures (huge thanks to @ArturoSbr, @GasparGarciaBaez and @mikegrados for the contribution!), also dependencies and description to pyproject.toml | READY |
 | 3.2.5 | Fixes Moebius utf-8 issue, adds create_tutorials(), <br>adds generate_color_palette(), improves Moebius example, <br>adds python 3.13 support. | READY |
 | 3.2.4 | Implements Moebius as anywidget for modern Jupyterlab | READY |
 | 3.2.3 | Fixes Moebius in Google Colab and update docs | READY |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Release  | Feature link to discussion | State |
 | -------- | -------------------------- | ----- |
-| 3.2.6 | Adds GraphFeatures (huge thanks to @ArturoSbr, @GasparGarciaBaez and @mikegrados for the contribution!), also dependencies and description to pyproject.toml | READY |
+| 3.2.6 | Adds GraphFeatures (huge thanks to @ArturoSbr, @GasparGarciaBaez and @mikegrados for the contribution!) and adds compatibility with Spark Connect in Databricks (huge thanks to @rjurney!) | READY |
 | 3.2.5 | Fixes Moebius utf-8 issue, adds create_tutorials(), <br>adds generate_color_palette(), improves Moebius example, <br>adds python 3.13 support. | READY |
 | 3.2.4 | Implements Moebius as anywidget for modern Jupyterlab | READY |
 | 3.2.3 | Fixes Moebius in Google Colab and update docs | READY |

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@
 
 * Interactive graph visualization: The Moebius class [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/BBVA/mercury-graph/blob/master/tutorials/moebius_demo.ipynb)
 
+* Graph-based feature engineering with mercury.graph [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/BBVA/mercury-graph/blob/master/tutorials/mercury-graph-tutorial-graph-features.ipynb)
+
 
 ## Install
 

--- a/docs/reference/ml.md
+++ b/docs/reference/ml.md
@@ -7,3 +7,5 @@
 ::: mercury.graph.ml.SpectralClustering
 
 ::: mercury.graph.ml.Transition
+
+::: mercury.graph.ml.GraphFeatures

--- a/mercury/graph/__init__.py
+++ b/mercury/graph/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.2.5'
+__version__ = '3.2.6'
 
 from .create_tutorials import create_tutorials
 

--- a/mercury/graph/ml/__init__.py
+++ b/mercury/graph/ml/__init__.py
@@ -3,3 +3,4 @@ from mercury.graph.ml.louvain import LouvainCommunities
 from mercury.graph.ml.transition import Transition
 from mercury.graph.ml.spark_randomwalker import SparkRandomWalker
 from mercury.graph.ml.spark_spreadactivation import SparkSpreadingActivation
+from mercury.graph.ml.graph_features import GraphFeatures

--- a/mercury/graph/ml/graph_features.py
+++ b/mercury/graph/ml/graph_features.py
@@ -25,11 +25,11 @@ class GraphFeatures(BaseClass):
     """Generate features from neighboring nodes.
 
         Args:
-            attributes : str or List[str], optional
+            attributes (str or List[str], optional):
                 The node attributes used to generate features. These strings
                 must be valid column names in the graph's vertices'. If None,
                 all columns except for 'id' are used. Default is None.
-            agg_funcs : str or List[str], optional
+            agg_funcs (str or List[str], optional):
                 The aggregation function(s) to apply. Supported values are:
                 - "sum"
                 - "min"
@@ -37,20 +37,20 @@ class GraphFeatures(BaseClass):
                 - "avg"
                 - "wavg"
                 Default is "avg".
-            order : int, optional
+            order (int, optional):
                 The order of neighbors to compute (e.g., 1 for immediate
                 neighbors, 2 for neighbors of neighbors, etc.). It must be a
                 positive integer. Default is 1.
-            verify : bool, optional
+            verify (bool, optional):
                 Whether to validate the provided parameters before executing
                 the algorithm. Default is False.
-            checkpoint : bool, optional
+            checkpoint (bool, optional):
                 Whether to use Spark checkpointing to persist intermediate
                 results. Default is False.
-            checkpoint_dir : str, optional,
+            checkpoint_dir (str, optional):
                 The directory to store checkpoint files if checkpointing is
                 enabled. Required if `checkpoint=True`. Default is None.
-            spark : SparkSession, optional
+            spark (SparkSession, optional):
                 The active Spark session. Required if `checkpoint=True`.
                 Default is None.
 

--- a/mercury/graph/ml/graph_features.py
+++ b/mercury/graph/ml/graph_features.py
@@ -1,22 +1,21 @@
-from mercury.graph.core.base import BaseClass
-from mercury.graph.core import Graph
-from mercury.graph.core.spark_interface import pyspark_installed, SparkInterface
-
-
-# Imports for framework
 import warnings
 from itertools import product
 from typing import Union, List
+from mercury.graph.core.base import BaseClass
+from mercury.graph.core import Graph
+from mercury.graph.core.spark_interface import pyspark_installed
 
 # Pyspark imports
 if pyspark_installed:
     from pyspark.sql import functions as F, Window as W, DataFrame, SparkSession
     # Use these to verify attribute data types
     from pyspark.sql.types import (
-        ByteType, ShortType, IntegerType, LongType, 
+        ByteType, ShortType, IntegerType, LongType,
         FloatType, DoubleType, DecimalType
     )
 
+
+# Main class to be fitted
 class GraphFeatures(BaseClass):
     def __init__(
             self,
@@ -47,8 +46,8 @@ class GraphFeatures(BaseClass):
                 2 for neighbors of neighbors, etc.). It must be a positive integer.
                 Default is 1.
             verify : bool, optional
-                Whether to validate the provided parameters before executing the algorithm.
-                Default is False.
+                Whether to validate the provided parameters before executing the
+                algorithm. Default is False.
             checkpoint : bool, optional
                 Whether to use Spark checkpointing to persist intermediate results.
                 Default is False.
@@ -72,14 +71,14 @@ class GraphFeatures(BaseClass):
             product of attribute values and edge weights, normalized by the total
             weight.
         """
-        
+
         self.attributes = attributes
-        self.agg_funcs  = agg_funcs
+        self.agg_funcs = agg_funcs
         self.order = order
         self.verify = verify
         self.checkpoint = checkpoint
         self.checkpoint_dir = checkpoint_dir
-        self.spark = spark 
+        self.spark = spark
 
     def _str_(self):
         pass
@@ -330,7 +329,6 @@ class GraphFeatures(BaseClass):
                 'float', 'double', 'tinyint', 'smallint', 'int', 'bigint'
             ), msg.format(dtype)
 
-
     # Fetches all the neighbors of each node in edges
     def _get_neighbors(
         self,
@@ -451,6 +449,3 @@ class GraphFeatures(BaseClass):
                 ret = ret_tmp
         # Return
         return ret
-
-
-    

--- a/mercury/graph/ml/graph_features.py
+++ b/mercury/graph/ml/graph_features.py
@@ -1,0 +1,455 @@
+from mercury.graph.core.base import BaseClass
+from mercury.graph.core import Graph
+from mercury.graph.core.spark_interface import pyspark_installed, SparkInterface
+
+
+# Imports for framework
+import warnings
+from itertools import product
+from typing import Union, List
+
+# Pyspark imports
+if pyspark_installed:
+    from pyspark.sql import functions as F, Window as W, DataFrame, SparkSession
+    # Use these to verify attribute data types
+    from pyspark.sql.types import (
+        ByteType, ShortType, IntegerType, LongType, 
+        FloatType, DoubleType, DecimalType
+    )
+
+class GraphFeatures(BaseClass):
+    def __init__(
+            self,
+            attributes: Union[str, List[str]] = None,
+            agg_funcs: Union[str, List[str]] = 'avg',
+            order: int = 1,
+            verify: bool = False,
+            checkpoint: bool = False,
+            checkpoint_dir: str = None,
+            spark: SparkSession = None,
+            ):
+        """Aggregate attributes from neighboring nodes.
+
+        Args:
+            attributes : str or List[str], optional
+                The node attributes to aggregate. If None, all columns but 'id' in
+                'vertices' are used. Default is None.
+            agg_funcs : str or List[str], optional
+                The aggregation functions to apply. Supported values are:
+                - "sum"
+                - "min"
+                - "max"
+                - "avg"
+                - "wavg"
+                Default is "avg".
+            order : int, optional
+                The order of neighbors to compute (e.g., 1 for immediate neighbors,
+                2 for neighbors of neighbors, etc.). It must be a positive integer.
+                Default is 1.
+            verify : bool, optional
+                Whether to validate the provided parameters before executing the algorithm.
+                Default is False.
+            checkpoint : bool, optional
+                Whether to use Spark checkpointing to persist intermediate results.
+                Default is False.
+            checkpoint_dir : str, optional,
+                The directory to store checkpoint files if checkpointing is enabled.
+                Required if `checkpoint=True`. Default is None.
+            spark : SparkSession, optional
+                The active Spark session. Required if `checkpoint=True`. Default is
+                None.
+
+        Returns:
+            DataFrame
+                A Spark DataFrame with the aggregated attributes for each node. The
+                column names follow the format `<attribute>_<agg_func>`.
+
+        Notes:
+            - The `order` parameter specifies the depth of the neighborhood
+            considered  during aggregation.
+            - If `wavg` is specified in `agg_funcs`, the `edges` DataFrame must
+            include a 'weight' column. Weighted averages are computed as the
+            product of attribute values and edge weights, normalized by the total
+            weight.
+        """
+        
+        self.attributes = attributes
+        self.agg_funcs  = agg_funcs
+        self.order = order
+        self.verify = verify
+        self.checkpoint = checkpoint
+        self.checkpoint_dir = checkpoint_dir
+        self.spark = spark 
+
+    def _str_(self):
+        pass
+
+    # Aggregate messages from neighbors
+    def fit(self, g: Graph):
+        """
+        Args:
+            g (Graph): A mercury graph structure.
+
+        Returns:
+            (self): Fitted self (or raises an error).
+        """
+
+        # Get parameters
+        edges = g.graphframe.edges
+        vertices = g.graphframe.nodes
+        attributes = self.attributes
+        agg_funcs = self.agg_funcs
+        order = self.order
+        verify = self.verify
+        checkpoint = self.checkpoint
+        checkpoint_dir = self.checkpoint_dir
+        spark = self.spark
+
+        # Verify attributes
+        if attributes is None:
+            attributes = [col for col in vertices.columns if col != 'id']
+        elif isinstance(attributes, str):
+            attributes = [attributes]
+        else:
+            msg = 'attributes must be a list of strings.'
+            assert isinstance(attributes, list), msg
+            msg = 'All items in attributes must be strings.'
+            assert all(isinstance(item, str) for item in attributes), msg
+            msg = 'All items in attributes must exist in vertices.'
+            assert all(item in vertices.columns for item in attributes), msg
+            msg = 'attributes must only contain attributes ("id" was detected).'
+            assert 'id' not in attributes, msg
+
+        # Verify aggregation functions
+        agg_funcs = [agg_funcs] if isinstance(agg_funcs, str) else agg_funcs
+        msg = 'Invalid aggregation function. Please provide one or more of ' \
+            'the following valid options: "sum", "min", "max", "avg" or "wavg".'
+        assert all([func in _agg_dict.keys() for func in agg_funcs]), msg
+
+        # Verify vertices
+        verify and self._verify_vertices(vertices)
+
+        # Verify edges
+        verify and self._verify_edges(edges)
+
+        # Verify checkpoint configuration and Spark session integrity
+        if checkpoint:
+            assert checkpoint_dir is not None, (
+                'checkpoint_dir must be provided when checkpoint is True.'
+            )
+            assert spark is not None, (
+                'spark must be provided when checkpoint is True.'
+            )
+            assert isinstance(checkpoint_dir, str), (
+                f'Invalid type for checkpoint_dir: expected str (a valid path), but'
+                f' got {type(checkpoint_dir).__name__} instead.'
+            )
+            assert isinstance(spark, SparkSession), (
+                f'Invalid type for spark: expected SparkSession instance, but got '
+                f'{type(spark).__name__} instead.'
+            )
+
+        # Dictionary that maps agg_funcs to sql functions
+        _agg_dict = {
+            'sum': F.sum,
+            'min': F.min,
+            'max': F.max,
+            'avg': F.avg,
+            'wavg': F.sum
+        }
+        # Fetch neighbors
+        neighs = self._get_neighbors(
+            edges,
+            order,
+            checkpoint,
+            checkpoint_dir,
+            spark
+        )
+
+        # Fetch neighbors' attributes
+        ret = (
+            neighs
+            .join(
+                other=(
+                    vertices
+                    .select(
+                        F.col('id').alias('neigh'),
+                        *attributes
+                    )
+                ),
+                on='neigh',
+                how='left'
+            )
+        )
+
+        # Temporarily assign columns if user is calculating weighted averages
+        if 'wavg' in agg_funcs:
+            ret = ret.select(
+                F.expr('*'),
+                *[(F.col(x) * F.col('weight')).alias('w_' + x) for x in attributes]
+            )
+
+        # Combine functions and attributes
+        _agg = list(product(agg_funcs, attributes))
+
+        # Apply all functions to all attributes
+        ret = (
+            ret
+            .groupBy('id')
+            .agg(
+                *[
+                    _agg_dict[k](x).alias('_'.join([x, k]))
+                    for (k, x) in _agg if k != 'wavg'
+                ],
+                *[
+                    _agg_dict[k]('w_' + x).alias('_'.join([x, 'wavg']))
+                    for (k, x) in _agg if k == 'wavg'
+                ]
+            )
+        )
+
+        # Return result
+        self.node_features_ = ret
+        return self
+
+    # Check vertices integrity
+    def _verify_vertices(self, vertices: DataFrame):
+
+        # Check type
+        msg = 'vertices must be a PySpark DataFrame.'
+        assert isinstance(vertices, DataFrame), msg
+
+        # Check if id column exists
+        msg = "Column 'id' not listed in vertices."
+        assert 'id' in vertices.columns, msg
+
+        # Assert unique IDs
+        ids_duplicated = (
+            vertices
+            .select(
+                F.count('id').over(
+                    W.partitionBy('id')
+                ).alias('count')
+            )
+            .where(F.col('count') > 1)
+            .limit(1)
+            .count()
+        )
+        msg = 'vertices contains duplicated IDs.'
+        assert ids_duplicated == 0, msg
+
+        # Numeric Types
+        numeric_types = (
+            ByteType, ShortType,
+            IntegerType, LongType,
+            FloatType, DoubleType, DecimalType
+        )
+
+        # Check for nulls (dict where key=col_name and value=null_count)
+        nulls_dict = (
+            vertices
+            .select(
+                *[
+                    F.count(F.when(F.col(c).isNull(), c)).alias(c)
+                    for c in vertices.columns if c != 'id'
+                ]
+            )
+            .collect()[0]
+            .asDict()
+        )
+
+        # Check for nulls and data types every column in the DataFrame
+        for field in vertices.schema.fields:
+            col_name = field.name
+
+            # Skip column with IDs
+            if col_name == 'id':
+                continue
+            col_type = type(field.dataType)
+            col_nulls = nulls_dict[col_name]
+
+            # Data type check
+            assert (
+                col_type in numeric_types
+            ), f"Non-numeric values found in column '{col_name}'."
+
+            # Nulls check
+            if col_nulls > 0:
+                warnings.warn(
+                    f"Column '{col_name}' contains {col_nulls} null values"
+                )
+
+    # Check edges' integrity
+    def _verify_edges(self, edges):
+        # Check type
+        msg = 'edges must be a PySpark DataFrame.'
+        assert isinstance(edges, DataFrame), msg
+
+        # Assert edges
+        msg = 'Expected column "{}" not in edges'
+        assert 'src' in edges.columns, msg.format('src')
+        assert 'dst' in edges.columns, msg.format('dst')
+
+        # Assert unique pairs
+        pairs_duplicated = (
+            edges
+            .groupBy('src', 'dst')
+            .count()
+            .where(F.col('count') > 1)
+            .count()
+        )
+        msg = 'edges contains {} duplicated src-dst pairs.'
+        assert pairs_duplicated == 0, msg.format(pairs_duplicated)
+
+        # Assert undirected
+        pairs_mirrored = (
+            edges
+            .select('src', 'dst')
+            .unionByName(
+                edges
+                .where(F.col('src') != F.col('dst'))  # Drop self-loops
+                .select(
+                    F.col('dst').alias('src'),
+                    F.col('src').alias('dst')
+                )
+            )
+            .groupBy('src', 'dst')
+            .count()
+            .where(F.col('count') > 1)
+            .count()
+        )
+        msg = 'edges has mirrored edges. Directed graphs are not yet supported!'
+        assert pairs_mirrored == 0, msg
+
+        # Assert weight dtype
+        if 'weight' in edges.columns:
+            msg = 'Column "weight" must be a float or an int. Received {} instead.'
+            dtype = dict(edges.dtypes)['weight']
+            assert dtype in (
+                'float', 'double', 'tinyint', 'smallint', 'int', 'bigint'
+            ), msg.format(dtype)
+
+
+    # Fetches all the neighbors of each node in edges
+    def _get_neighbors(
+        self,
+        edges,
+        order,
+        checkpoint,
+        checkpoint_dir,
+        spark,
+    ):
+        """Fetch all the neighbors of each node in a graph up to specific order.
+
+        Args:
+            edges : DataFrame
+                A Spark DataFrame containing the edges of the graph. It must contain
+                the columns 'src' and 'dst' corresponding to source and destination
+                nodes, respectively. An optional 'weight' column can be included; if
+                not present, it is assumed to be 1.
+            order : int, optional
+                The order of neighbors to compute (e.g., 1 for immediate neighbors,
+                2 for neighbors of neighbors, etc.). It must be a positive integer.
+                Default is 1.
+            checkpoint : bool, optional
+                Whether to use Spark checkpointing to persist intermediate results.
+                Default is False.
+            checkpoint_dir : str, optional,
+                The directory to store checkpoint files if checkpointing is enabled.
+                Required if `checkpoint=True`. Default is None.
+            spark : SparkSession, optional
+                The active Spark session. Required if `checkpoint=True`. Default is
+                None.
+
+        Returns:
+            DataFrame
+                A Spark DataFrame with the columns:
+                - 'id': The node ID.
+                - 'neigh': The ID of a neighboring node.
+                - 'weight': The computed weight of the edge connecting 'id' to
+                'neigh', normalized by the total weight of all edges originating
+                from 'id'.
+
+        Notes:
+            - Self-loops are removed when calculating weighted aggregations.
+        """
+        # Add weight column if necessary
+        if 'weight' not in edges.columns:
+            edges = edges.withColumn('weight', F.lit(1))
+
+        # Assert order
+        assert isinstance(order, int), 'order must be an integer.'
+        assert order > 0, 'order must be an integer greater than 0.'
+        if order > 2:
+            warnings.warn(
+                f"order={order} may cause the process to be slow."
+            )
+
+        # Fetch first-degree neighbors (preserve self-loops for weighted degree)
+        ret = (
+            edges
+            .unionByName(
+                edges
+                .select(
+                    F.col('dst').alias('src'),
+                    F.col('src').alias('dst'),
+                    'weight'
+                )
+            )
+            # Get weights (accounting for self-loops)
+            .select(
+                F.col('src').alias('id'),
+                F.col('dst').alias('neigh'),
+                (
+                    F.col('weight')
+                    / F.sum('weight').over(
+                        W.partitionBy(F.col('src'))
+                    )
+                ).alias('weight')
+            )
+            # Drop self-loops AFTER calculating weights
+            .where(F.col('id') != F.col('neigh'))
+        )
+
+        # checkpoint result
+        if checkpoint:
+            spark.sparkContext.setCheckpointDir(checkpoint_dir)
+            ret = ret.checkpoint()
+
+        # Fetch n-degree neighbors
+        for _ in range(1, order):
+            ret_tmp = (
+                ret.select(
+                    F.col('id'),
+                    F.col('neigh').alias('o1_neigh'),
+                    F.col('weight').alias('o1_weight')
+                )
+                .join(
+                    other=ret.select(
+                        F.col('id').alias('o1_neigh'),
+                        F.col('neigh').alias('o2_neigh'),
+                        F.col('weight').alias('o2_weight')
+                    ),
+                    on='o1_neigh',
+                    how='left'
+                )
+                # Drop paths back to self
+                .where(F.col('id') != F.col('o2_neigh'))
+                .select(
+                    F.col('id'),
+                    F.col('o2_neigh').alias('neigh'),
+                    (
+                        F.col('o1_weight') * F.col('o2_weight')
+                    ).alias('weight')
+                )
+            )
+            # checkpoint result
+            if checkpoint:
+                ret = ret_tmp.checkpoint()
+            else:
+                ret = ret_tmp
+        # Return
+        return ret
+
+
+    

--- a/mercury/graph/ml/graph_features.py
+++ b/mercury/graph/ml/graph_features.py
@@ -138,15 +138,15 @@ class GraphFeatures(BaseClass):
             assert all(isinstance(item, str) for item in attributes), msg
             msg = 'All items in attributes must exist in vertices.'
             assert all(item in vertices.columns for item in attributes), msg
-            msg = 'attributes must only contain attributes ("id" was \
-                detected).'
+            msg = 'attributes must only contain attributes ("id" was detected).'
             assert 'id' not in attributes, msg
 
         # Verify aggregation functions
         agg_funcs = [agg_funcs] if isinstance(agg_funcs, str) else agg_funcs
-        msg = 'Invalid aggregation function. Please provide one or more of ' \
-            'the following valid options: "sum", "min", "max", "avg" or \
-            "wavg".'
+        msg = (
+            'Invalid aggregation function. Please provide one or more of the following '
+            'valid options: "sum", "min", "max", "avg" or "wavg".'
+        )
         assert all([func in _agg_dict.keys() for func in agg_funcs]), msg
 
         # Verify vertices
@@ -164,13 +164,11 @@ class GraphFeatures(BaseClass):
                 'spark must be provided when checkpoint is True.'
             )
             assert isinstance(checkpoint_dir, str), (
-                f'Invalid type for checkpoint_dir: expected str (a valid \
-                path), but'
-                f' got {type(checkpoint_dir).__name__} instead.'
+                'Invalid type for checkpoint_dir: expected str (a valid path), but got'
+                f' {type(checkpoint_dir).__name__} instead.'
             )
             assert isinstance(spark, SparkSession), (
-                f'Invalid type for spark: expected SparkSession instance, \
-                but got '
+                'Invalid type for spark: expected SparkSession instance, but got '
                 f'{type(spark).__name__} instead.'
             )
 
@@ -363,14 +361,12 @@ class GraphFeatures(BaseClass):
             .where(F.col('count') > 1)
             .count()
         )
-        msg = 'edges has mirrored edges. Directed graphs are not yet \
-            supported!'
+        msg = 'edges has mirrored edges. Directed graphs are not yet supported!'
         assert pairs_mirrored == 0, msg
 
         # Assert weight dtype
         if 'weight' in edges.columns:
-            msg = 'Column "weight" must be a float or an int. Received \
-                {} instead.'
+            msg = 'Column "weight" must be a float or an int. Received {} instead.'
             dtype = dict(edges.dtypes)['weight']
             assert dtype in (
                 'float', 'double', 'tinyint', 'smallint', 'int', 'bigint'

--- a/mercury/graph/ml/graph_features.py
+++ b/mercury/graph/ml/graph_features.py
@@ -96,7 +96,7 @@ class GraphFeatures(BaseClass):
 
         # Get parameters
         edges = g.graphframe.edges
-        vertices = g.graphframe.nodes
+        vertices = g.graphframe.vertices
         attributes = self.attributes
         agg_funcs = self.agg_funcs
         order = self.order
@@ -104,6 +104,15 @@ class GraphFeatures(BaseClass):
         checkpoint = self.checkpoint
         checkpoint_dir = self.checkpoint_dir
         spark = self.spark
+
+        # Dictionary that maps agg_funcs to sql functions
+        _agg_dict = {
+            'sum': F.sum,
+            'min': F.min,
+            'max': F.max,
+            'avg': F.avg,
+            'wavg': F.sum
+        }
 
         # Verify attributes
         if attributes is None:
@@ -149,14 +158,6 @@ class GraphFeatures(BaseClass):
                 f'{type(spark).__name__} instead.'
             )
 
-        # Dictionary that maps agg_funcs to sql functions
-        _agg_dict = {
-            'sum': F.sum,
-            'min': F.min,
-            'max': F.max,
-            'avg': F.avg,
-            'wavg': F.sum
-        }
         # Fetch neighbors
         neighs = self._get_neighbors(
             edges,

--- a/mercury/graph/ml/graph_features.py
+++ b/mercury/graph/ml/graph_features.py
@@ -61,6 +61,16 @@ class GraphFeatures(BaseClass):
             include a 'weight' column. Weighted averages are computed as the
             product of attribute values and edge weights, normalized by the
             total weight.
+            - Loops back to oneself are excluded (e.g., 0 -> 1 -> 0).
+
+        Examples:
+            >>> g = Graph(data=edges, nodes=vertices, keys={"directed": False})
+            >>> gf = GraphFeatures(
+            ...     attributes=["feature1", "feature2"],  # Valid names in `vertices`
+            ...     agg_funcs=["min", "max", "avg"]
+            ... )
+            >>> gf.fit(g)  # Adds `node_features_` attribute to `gf`
+            >>> gf.node_features_.show(5)  # Display new graph features
         """
 
     def __init__(

--- a/mercury/graph/ml/graph_features.py
+++ b/mercury/graph/ml/graph_features.py
@@ -75,7 +75,7 @@ class GraphFeatures(BaseClass):
         self.checkpoint_dir = checkpoint_dir
         self.spark = spark
 
-    def _str_(self):
+    def __str__(self):
         pass
 
     # Aggregate messages from neighbors

--- a/mercury/graph/ml/graph_features.py
+++ b/mercury/graph/ml/graph_features.py
@@ -281,7 +281,7 @@ class GraphFeatures(BaseClass):
                 )
 
     # Check edges' integrity
-    def _verify_edges(self, edges):
+    def _verify_edges(self, edges: DataFrame):
         # Check type
         msg = 'edges must be a PySpark DataFrame.'
         assert isinstance(edges, DataFrame), msg
@@ -333,11 +333,11 @@ class GraphFeatures(BaseClass):
     # Fetches all the neighbors of each node in edges
     def _get_neighbors(
         self,
-        edges,
-        order,
-        checkpoint,
-        checkpoint_dir,
-        spark,
+        edges: DataFrame,
+        order: int = 1,
+        checkpoint: bool = False,
+        checkpoint_dir: str = None,
+        spark: SparkSession = None,
     ):
         """Fetch all the neighbors of each node in a graph up to specific order.
 

--- a/mercury/graph/ml/graph_features.py
+++ b/mercury/graph/ml/graph_features.py
@@ -8,7 +8,12 @@ from mercury.graph.core.spark_interface import pyspark_installed
 
 # Pyspark imports
 if pyspark_installed:
-    from pyspark.sql import functions as F, Window as W, DataFrame, SparkSession
+    from pyspark.sql import (
+        functions as F, 
+        Window as W, 
+        DataFrame, 
+        SparkSession
+    )
     from pyspark.sql.types import (
         ByteType, ShortType, IntegerType, LongType,
         FloatType, DoubleType, DecimalType

--- a/mercury/graph/ml/graph_features.py
+++ b/mercury/graph/ml/graph_features.py
@@ -1,3 +1,4 @@
+# Imports
 import warnings
 from itertools import product
 from typing import Union, List
@@ -8,7 +9,6 @@ from mercury.graph.core.spark_interface import pyspark_installed
 # Pyspark imports
 if pyspark_installed:
     from pyspark.sql import functions as F, Window as W, DataFrame, SparkSession
-    # Use these to verify attribute data types
     from pyspark.sql.types import (
         ByteType, ShortType, IntegerType, LongType,
         FloatType, DoubleType, DecimalType
@@ -26,15 +26,16 @@ class GraphFeatures(BaseClass):
             checkpoint: bool = False,
             checkpoint_dir: str = None,
             spark: SparkSession = None,
-            ):
+        ):
         """Aggregate attributes from neighboring nodes.
 
         Args:
             attributes : str or List[str], optional
-                The node attributes to aggregate. If None, all columns but 'id' in
-                'vertices' are used. Default is None.
+                The node attributes used to generate features. These strings must be
+                valid column names 'vertices'. If None, all columns except for 'id'
+                are used. Default is None.
             agg_funcs : str or List[str], optional
-                The aggregation functions to apply. Supported values are:
+                The aggregation function(s) to apply. Supported values are:
                 - "sum"
                 - "min"
                 - "max"
@@ -58,11 +59,6 @@ class GraphFeatures(BaseClass):
                 The active Spark session. Required if `checkpoint=True`. Default is
                 None.
 
-        Returns:
-            DataFrame
-                A Spark DataFrame with the aggregated attributes for each node. The
-                column names follow the format `<attribute>_<agg_func>`.
-
         Notes:
             - The `order` parameter specifies the depth of the neighborhood
             considered  during aggregation.
@@ -71,7 +67,6 @@ class GraphFeatures(BaseClass):
             product of attribute values and edge weights, normalized by the total
             weight.
         """
-
         self.attributes = attributes
         self.agg_funcs = agg_funcs
         self.order = order
@@ -85,12 +80,13 @@ class GraphFeatures(BaseClass):
 
     # Aggregate messages from neighbors
     def fit(self, g: Graph):
-        """
+        """Fit the GraphFeatures object to generate graph-based features.
+
         Args:
             g (Graph): A mercury graph structure.
 
         Returns:
-            (self): Fitted self (or raises an error).
+            (self): Fitted self with 'node_features_' attribute (or raises an error).
         """
 
         # Get parameters

--- a/mercury/graph/ml/graph_features.py
+++ b/mercury/graph/ml/graph_features.py
@@ -22,13 +22,13 @@ if pyspark_installed:
 
 # Main class to be fitted
 class GraphFeatures(BaseClass):
-    """Aggregate attributes from neighboring nodes.
+    """Generate features from neighboring nodes.
 
         Args:
             attributes : str or List[str], optional
                 The node attributes used to generate features. These strings
-                must be valid column names in 'vertices'. If None, all columns
-                except for 'id' are used. Default is None.
+                must be valid column names in the graph's vertices'. If None,
+                all columns except for 'id' are used. Default is None.
             agg_funcs : str or List[str], optional
                 The aggregation function(s) to apply. Supported values are:
                 - "sum"
@@ -73,7 +73,6 @@ class GraphFeatures(BaseClass):
             checkpoint_dir: str = None,
             spark: SparkSession = None,
     ):
-
         self.attributes = attributes
         self.agg_funcs = agg_funcs
         self.order = order
@@ -90,11 +89,11 @@ class GraphFeatures(BaseClass):
         """Fit the GraphFeatures object to generate graph-based features.
 
         Args:
-            g (Graph): A mercury graph structure.
+            g (Graph): A mercury graph object (mercury.graph.core.graph.Graph).
 
         Returns:
             (self): Fitted self with 'node_features_' attribute (or raises an
-                    error).
+                error).
         """
 
         # Get parameters

--- a/mercury/version.py
+++ b/mercury/version.py
@@ -1,3 +1,3 @@
 # The source version file is <proj>/mercury/version.py, anything else is auto generated.
-__version__ = '3.2.5'
+__version__ = '3.2.6'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend	= 'setuptools.build_meta'
 
 [project]
 name			= 'mercury-graph'
-version			= '3.2.5'
+version			= '3.2.6'
 description		= '.'
 license			= {file = "LICENSE"}
 requires-python = '>=3.8'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend	= 'setuptools.build_meta'
 [project]
 name			= 'mercury-graph'
 version			= '3.2.6'
-description		= '.'
+description		= 'mercury-graph offers graph analytics capabilities with a technology-agnostic API'
 license			= {file = "LICENSE"}
 requires-python = '>=3.8'
 classifiers		= ['Programming Language :: Python :: 3',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,11 @@ classifiers		= ['Programming Language :: Python :: 3',
 keywords		= ['graph', 'embedding', 'graph embedding', 'graph exploration', 'graph metrics', 'graph visualization']
 authors			= [{name = 'Mercury Team', email = 'mercury.group@bbva.com'}]
 readme			= 'README.md'
+dependencies 	= ['numpy', 'pandas', 'scipy', 'networkx', 'scikit-learn', 'anywidget', 'traitlets']
+
+[project.optional-dependencies]
+dev = ['pytest', 'coverage', 'flake8', 'graphframes-latest', 'pyspark', 'matplotlib', 'seaborn', 'pyyaml', 'setuptools>=61.0', 'ipywidgets', 'pyvis']
+doc = ['mkdocs', 'mkdocstrings[python]', 'mkdocs-material', 'mkdocs-minify-plugin==0.5.0', 'mkdocs-exclude', 'nbconvert', 'pyyaml']
 
 [tool.setuptools]
 include-package-data = true

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,4 @@ filterwarnings =
     ignore::DeprecationWarning:networkx.algorithms.link_analysis.pagerank_alg
     ignore::DeprecationWarning:networkx.linalg.graphmatrix
     ignore::scipy.sparse.SparseEfficiencyWarning
+	ignore:pkg_resources is deprecated as an API:DeprecationWarning

--- a/tutorials/mercury-graph-tutorial-graph-features.ipynb
+++ b/tutorials/mercury-graph-tutorial-graph-features.ipynb
@@ -1,0 +1,224 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Graph-Based Feature Engineering with Mercury Graph\n",
+        "This notebook uses an AI-generated dataset to generate graph-based features using Mercury Graph."
+      ],
+      "metadata": {
+        "id": "6iP4gH787MGt"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Environment"
+      ],
+      "metadata": {
+        "id": "JoU9NbUNWLPW"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install graphframes\n",
+        "!pip install anywidget\n",
+        "!git clone --branch feature/graph_features --single-branch https://github.com/BBVA/mercury-graph.git\n",
+        "%cd mercury-graph\n",
+        "!git checkout feature/graph_features"
+      ],
+      "metadata": {
+        "collapsed": true,
+        "id": "bWznxL7nkCnh"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Setting up the environment\n",
+        "Let's start off by importing the necessary dependencies"
+      ],
+      "metadata": {
+        "id": "uwJhIobWWT5o"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import pandas as pd\n",
+        "import mercury.graph as mg\n",
+        "from mercury.graph.ml.graph_features import GraphFeatures\n",
+        "from pyspark.context import SparkContext\n",
+        "from pyspark.sql import SparkSession"
+      ],
+      "metadata": {
+        "id": "yBwOY-qievhB"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let's set up a pyspark session"
+      ],
+      "metadata": {
+        "id": "EGIpXErwZ0OT"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "spark = (\n",
+        "    SparkSession.builder.appName(\"graphs\")\n",
+        "    .config(\"spark.jars.packages\", \"graphframes:graphframes:0.8.3-spark3.5-s_2.12\")\n",
+        "    .getOrCreate()\n",
+        ")"
+      ],
+      "metadata": {
+        "id": "hFeNg5frZ3Os"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Loading the data\n",
+        "We now load the vertices and edges data directly from the CSV files available in the project repository."
+      ],
+      "metadata": {
+        "id": "_ZTZVRG1W_Wd"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Declare paths\n",
+        "PATH = \"https://raw.githubusercontent.com/BBVA/mercury-graph/refs/heads/master/\"\n",
+        "PATH_V = PATH + \"tutorials/data/chamberi_nodos.csv\"\n",
+        "PATH_E = PATH + \"tutorials/data/chamberi_aristas.csv\"\n",
+        "\n",
+        "# Read data\n",
+        "vertices = pd.read_csv(PATH_V, sep='\\t', usecols=[\"id\", \"facturación\", \"precio_medio\"])\n",
+        "edges = pd.read_csv(PATH_E, sep = '\\t')\n",
+        "\n",
+        "# Rename columns\n",
+        "vertices.columns = [\"id\", \"revenue\", \"mean_price\"]"
+      ],
+      "metadata": {
+        "id": "oDAIoIrafEEP"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Declare a graph\n",
+        "\n",
+        "* Construct a graph from the loaded nodes and edges, leveraging the core `Graph` class from Mercury-Graph."
+      ],
+      "metadata": {
+        "id": "O8SOgZmuYGnF"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "g = mg.core.Graph(\n",
+        "    data=edges,\n",
+        "    nodes=vertices,\n",
+        "    keys={\"directed\": False}\n",
+        ")"
+      ],
+      "metadata": {
+        "id": "WZMOjqhNfkjo"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Feature Engineering: Message Aggregation\n",
+        "\n",
+        "* The objective is to obtain the average revenue of all neighboring businesses.\n",
+        "* Additionally, we also calculate the weighted average of this revenue level.\n",
+        "\n",
+        "By doing this, we go from having a single feature per node to three: the original value and two new variables, which provide additional information about the environment and relationships of each business."
+      ],
+      "metadata": {
+        "id": "mDdwXzd9dDIv"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Init GraphFeatures isntance\n",
+        "gf = GraphFeatures(\n",
+        "    attributes=[\"revenue\", \"mean_price\"],\n",
+        "    agg_funcs=[\"min\", \"avg\", \"max\"]\n",
+        ")\n",
+        "\n",
+        "# Fit instance\n",
+        "gf.fit(g)\n",
+        "\n",
+        "# View generated attributes\n",
+        "gf.node_features_.show(5)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "OH3zpPPtf_oc",
+        "outputId": "9a4103f7-4b74-461a-b206-70afb2c78e53"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.11/dist-packages/pyspark/sql/dataframe.py:168: UserWarning: DataFrame.sql_ctx is an internal property, and will be removed in future releases. Use DataFrame.sparkSession instead.\n",
+            "  warnings.warn(\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "+------------------+-----------+--------------+-----------------+--------------+-----------+--------------+\n",
+            "|                id|revenue_min|mean_price_min|      revenue_avg|mean_price_avg|revenue_max|mean_price_max|\n",
+            "+------------------+-----------+--------------+-----------------+--------------+-----------+--------------+\n",
+            "|  Horno del Barrio|      27080|             5|         45481.25|          20.0|      74525|            40|\n",
+            "|Juegos y Aventuras|      28120|            12|67619.66666666667|          37.0|     106788|            60|\n",
+            "|La Boutique de Luz|      44688|            12|          75020.6|          33.4|     102090|            60|\n",
+            "|        Gambón Hub|      44300|             5|          82942.0|          52.0|     141000|           150|\n",
+            "|Flores de Chamberí|      16300|            20|          53330.0|         36.25|      98400|            60|\n",
+            "+------------------+-----------+--------------+-----------------+--------------+-----------+--------------+\n",
+            "only showing top 5 rows\n",
+            "\n"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tutorials/mercury-graph-tutorial-graph-features.ipynb
+++ b/tutorials/mercury-graph-tutorial-graph-features.ipynb
@@ -1,115 +1,109 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
+      "metadata": {},
       "source": [
-        "# Graph-Based Feature Engineering with Mercury Graph\n",
-        "This notebook uses an AI-generated dataset to generate graph-based features using Mercury Graph."
-      ],
-      "metadata": {
-        "id": "6iP4gH787MGt"
-      }
+        "<a href=\"https://colab.research.google.com/github/BBVA/mercury-graph/blob/master/tutorials/mercury-graph-tutorial-graph-features.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "6iP4gH787MGt"
+      },
       "source": [
-        "## Environment"
-      ],
+        "# Graph-Based Feature Engineering with Mercury Graph\n",
+        "This notebook uses an AI-generated dataset to generate graph-based features using Mercury Graph."
+      ]
+    },
+    {
+      "cell_type": "markdown",
       "metadata": {
         "id": "JoU9NbUNWLPW"
-      }
+      },
+      "source": [
+        "## Environment"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "!pip install graphframes\n",
-        "!pip install anywidget\n",
-        "!git clone --branch feature/graph_features --single-branch https://github.com/BBVA/mercury-graph.git\n",
-        "%cd mercury-graph\n",
-        "!git checkout feature/graph_features"
-      ],
+      "execution_count": null,
       "metadata": {
         "collapsed": true,
         "id": "bWznxL7nkCnh"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "!pip install mercury-graph graphframes anywidget"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "uwJhIobWWT5o"
+      },
       "source": [
         "## Setting up the environment\n",
         "Let's start off by importing the necessary dependencies"
-      ],
-      "metadata": {
-        "id": "uwJhIobWWT5o"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "yBwOY-qievhB"
+      },
+      "outputs": [],
       "source": [
         "import pandas as pd\n",
         "import mercury.graph as mg\n",
         "from mercury.graph.ml.graph_features import GraphFeatures\n",
         "from pyspark.context import SparkContext\n",
         "from pyspark.sql import SparkSession"
-      ],
-      "metadata": {
-        "id": "yBwOY-qievhB"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Let's set up a pyspark session"
-      ],
       "metadata": {
         "id": "EGIpXErwZ0OT"
-      }
+      },
+      "source": [
+        "Let's set up a pyspark session"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "hFeNg5frZ3Os"
+      },
+      "outputs": [],
       "source": [
         "spark = (\n",
         "    SparkSession.builder.appName(\"graphs\")\n",
         "    .config(\"spark.jars.packages\", \"graphframes:graphframes:0.8.3-spark3.5-s_2.12\")\n",
         "    .getOrCreate()\n",
         ")"
-      ],
-      "metadata": {
-        "id": "hFeNg5frZ3Os"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "_ZTZVRG1W_Wd"
+      },
       "source": [
         "## Loading the data\n",
         "We now load the vertices and edges data directly from the CSV files available in the project repository."
-      ],
-      "metadata": {
-        "id": "_ZTZVRG1W_Wd"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "oDAIoIrafEEP"
+      },
+      "outputs": [],
       "source": [
         "# Declare paths\n",
         "PATH = \"https://raw.githubusercontent.com/BBVA/mercury-graph/refs/heads/master/\"\n",
@@ -122,41 +116,39 @@
         "\n",
         "# Rename columns\n",
         "vertices.columns = [\"id\", \"revenue\", \"mean_price\"]"
-      ],
-      "metadata": {
-        "id": "oDAIoIrafEEP"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "O8SOgZmuYGnF"
+      },
       "source": [
         "## Declare a graph\n",
         "\n",
         "* Construct a graph from the loaded nodes and edges, leveraging the core `Graph` class from Mercury-Graph."
-      ],
-      "metadata": {
-        "id": "O8SOgZmuYGnF"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "WZMOjqhNfkjo"
+      },
+      "outputs": [],
       "source": [
         "g = mg.core.Graph(\n",
         "    data=edges,\n",
         "    nodes=vertices,\n",
         "    keys={\"directed\": False}\n",
         ")"
-      ],
-      "metadata": {
-        "id": "WZMOjqhNfkjo"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "mDdwXzd9dDIv"
+      },
       "source": [
         "### Feature Engineering: Message Aggregation\n",
         "\n",
@@ -164,26 +156,11 @@
         "* Additionally, we also calculate the weighted average of this revenue level.\n",
         "\n",
         "By doing this, we go from having a single feature per node to three: the original value and two new variables, which provide additional information about the environment and relationships of each business."
-      ],
-      "metadata": {
-        "id": "mDdwXzd9dDIv"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# Init GraphFeatures isntance\n",
-        "gf = GraphFeatures(\n",
-        "    attributes=[\"revenue\", \"mean_price\"],\n",
-        "    agg_funcs=[\"min\", \"avg\", \"max\"]\n",
-        ")\n",
-        "\n",
-        "# Fit instance\n",
-        "gf.fit(g)\n",
-        "\n",
-        "# View generated attributes\n",
-        "gf.node_features_.show(5)"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -191,19 +168,18 @@
         "id": "OH3zpPPtf_oc",
         "outputId": "9a4103f7-4b74-461a-b206-70afb2c78e53"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stderr",
+          "output_type": "stream",
           "text": [
             "/usr/local/lib/python3.11/dist-packages/pyspark/sql/dataframe.py:168: UserWarning: DataFrame.sql_ctx is an internal property, and will be removed in future releases. Use DataFrame.sparkSession instead.\n",
             "  warnings.warn(\n"
           ]
         },
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "+------------------+-----------+--------------+-----------------+--------------+-----------+--------------+\n",
             "|                id|revenue_min|mean_price_min|      revenue_avg|mean_price_avg|revenue_max|mean_price_max|\n",
@@ -218,7 +194,34 @@
             "\n"
           ]
         }
+      ],
+      "source": [
+        "# Init GraphFeatures isntance\n",
+        "gf = GraphFeatures(\n",
+        "    attributes=[\"revenue\", \"mean_price\"],\n",
+        "    agg_funcs=[\"min\", \"avg\", \"max\"]\n",
+        ")\n",
+        "\n",
+        "# Fit instance\n",
+        "gf.fit(g)\n",
+        "\n",
+        "# View generated attributes\n",
+        "gf.node_features_.show(5)"
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/unit_tests/test_graph_features.py
+++ b/unit_tests/test_graph_features.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import warnings
 from mercury.graph.core import Graph
@@ -6,22 +7,10 @@ from mercury.graph.ml.graph_features import GraphFeatures
 
 # Init spark if available
 if pyspark_installed:
-    import os
-    os.environ["JAVA_HOME"] = "/Users/mi20371/homebrew/opt/openjdk@11"
-    os.environ["SPARK_HOME"] = "/Users/mi20371/miniconda3/envs/contribenv/lib/python3.9/site-packages/pyspark"  # Configura la ruta correcta a Spark
-    os.environ["PYSPARK_PYTHON"] = "/Users/mi20371/miniconda3/envs/contribenv/bin/python"
-    os.environ["PYSPARK_DRIVER_PYTHON"] ="/Users/mi20371/miniconda3/envs/contribenv/bin/python"
-
     from pyspark.context import SparkContext
     from pyspark.sql import SparkSession
-    #sc = SparkContext.getOrCreate()
-
-    spark = SparkSession.builder \
-        .appName("GraphFrames Example") \
-        .config("spark.jars.packages", "graphframes:graphframes:0.8.2-spark3.0-s_2.12") \
-        .getOrCreate()
-
-    #spark = SparkSession(sc)
+    sc = SparkContext.getOrCreate()
+    spark = SparkSession(sc)
     from pyspark.sql.types import (
         StructType,
         StructField,

--- a/unit_tests/test_graph_features.py
+++ b/unit_tests/test_graph_features.py
@@ -1,0 +1,360 @@
+import pytest
+import warnings
+from mercury.graph.core.spark_interface import pyspark_installed
+from mercury.graph.ml.graph_features import GraphFeatures
+from pyspark.sql.types import (
+    StructType,
+    StructField,
+    StringType,
+    IntegerType,
+    FloatType
+)
+from pyspark.sql import functions as F
+
+# Init spark if available
+if pyspark_installed:
+    from pyspark.context import SparkContext
+    from pyspark.sql import SparkSession
+    sc = SparkContext.getOrCreate()
+    spark = SparkSession(sc)
+
+# Declare vertices, edges and GraphFeatures instance
+v = spark.createDataFrame(
+    [(0, 42, "42", 42), (1, None, "42", 42)],
+    schema=StructType([
+        StructField("id", IntegerType(), False),
+        StructField("x1", IntegerType(), True),
+        StructField("x2", StringType(), True),
+        StructField("x3", StringType(), True)
+    ])
+)
+e = spark.createDataFrame(
+    [(0, 1, 1)],
+    schema=StructType([
+        StructField("src", IntegerType(), False),
+        StructField("dst", IntegerType(), True),
+    ])
+)
+gf = GraphFeatures()
+
+
+# _verify_vertices nulls
+def test_verify_vertices_warns():
+    with pytest.warns(UserWarning, match="Column 'x1' contains 1 null values"):
+        gf._verify_vertices(vertices=v.select("id", "x1"))
+
+
+# _verify_vertices dtypes
+def test_verify_vertices_non_numeric_error():
+    with pytest.raises(
+        AssertionError, match="Non-numeric values found in column 'x2'"
+    ):
+        gf._verify_vertices(vertices=v.select("id", "x2"))
+
+
+# _verify_edges (expected to pass)
+def test_verify_edges_success():
+    try:
+        gf._verify_vertices(v.select("id", "x3"))
+    except AssertionError:
+        pytest.fail("Valid vertices raised an unexpected AssertionError.")
+
+
+# _verify_edges src
+def test_verify_edges_src():
+    with pytest.raises(AssertionError, match='Expected column "src" not in edges'):
+        gf._verify_edges(e.select(F.col("src").alias("source")), "dst")
+
+
+# _verify_edges dst
+def test_verify_edges_dst():
+    with pytest.raises(AssertionError, match='Expected column "dst" not in edges'):
+        gf._verify_edges(e.select("src", F.col("dst").alias("dest")))
+
+
+# _verify_edges duplicates
+def test_verify_edges_duplicates():
+    with pytest.raises(
+        AssertionError, match="edges contains 1 duplicated src-dst pairs"
+    ):
+        gf._verify_edges(e.unionByName(e))
+
+
+# _verify_edges weight dtype
+def test_verify_edges_weight_type():
+    with pytest.raises(
+        AssertionError,
+        match='Column "weight" must be a float or an int. Received string instead',
+    ):
+        gf._verify_edges(e.select("src", "dst", F.lit("1").alias("weight")))
+
+
+# _verify_edges weight dtype
+def test_verify_edges_directed_graph():
+    with pytest.raises(
+        AssertionError,
+        match="edges has mirrored edges. Directed graphs are not yet supported!",
+    ):
+        gf._verify_edges(
+            e.unionByName(
+                e.select(F.col("dst").alias("src"), F.col("src").alias("dst"))
+        )
+    )
+
+
+# _verify_edges (expected to pass)
+def test_verify_edges_success():
+    try:
+        gf._verify_edges(e)
+    except AssertionError:
+        pytest.fail("Valid edges raised an unexpected AssertionError.")
+
+@pytest.fixture
+def dataset1():
+    dataset = (
+        spark
+        .createDataFrame(
+            [
+                (1, 2),
+                (1, 3),
+                (1, 4),
+                (2, 3),
+                (2, 4),
+                (3, 4),
+                (3, 5),
+                (4, 5),
+                (4, 6),
+                (5, 6),
+                (6, 7)
+            ],
+            schema=StructType([
+                StructField('src', StringType(), False),
+                StructField('dst', StringType(), False),
+            ])
+        )
+    )
+    return dataset
+
+
+@pytest.fixture
+def dataset2():
+    dataset = (
+        spark
+        .createDataFrame(
+            [
+                (1, 2, .7),
+                (1, 3, .2),
+                (1, 4, .1),
+                (2, 3, .2),
+                (2, 4, .1),
+                (3, 4, .3),
+                (3, 5, .3),
+                (4, 5, .3),
+                (4, 6, .2),
+                (5, 6, .4),
+                (6, 7, .2)
+            ],
+            schema=StructType([
+                StructField('src', StringType(), False),
+                StructField('dst', StringType(), False),
+                StructField('weight', FloatType(), True)
+            ])
+        )
+    )
+    return dataset
+
+
+@pytest.fixture
+def dataset3():
+    dataset = (
+        spark
+        .createDataFrame(
+            [
+                (1, 2),
+                (2, 3),
+                (3, 1),
+                (4, 5),
+                (5, 4),
+                (6, 6)
+            ],
+            schema=StructType([
+                StructField('src', StringType(), False),
+                StructField('dst', StringType(), False)
+            ])
+        )
+    )
+    return dataset
+
+
+@pytest.fixture
+def dataset4():
+    dataset = (
+        spark
+        .createDataFrame(
+            [
+                (1, 2, .5),
+                (2, 3, .5),
+                (3, 1, .5),
+                (4, 5, .5),
+                (5, 4, .5),
+                (6, 6, 1.0)
+            ],
+            schema=StructType([
+                StructField('src', StringType(), False),
+                StructField('dst', StringType(), False),
+                StructField('weight', FloatType(), True)
+            ])
+        )
+    )
+    return dataset
+
+
+@pytest.fixture
+def dataset5():
+    dataset = (
+        spark
+        .createDataFrame(
+            [
+                (0, 54, 27483.57, 0.0),
+                (1, 44, 24308.68, 1.0),
+                (2, 56, 28238.44, 0.0),
+                (3, 70, 32615.15, 0.0),
+                (4, 42, 23829.23, 0.0),
+                (5, 55, 25123.12, 1.0),
+                (6, 60, 29000.00, 0.0),
+                (7, 45, 28815.45, 1.0),
+                (8, 49, 30500.00, 1.0),
+                (9, 36, 22013.78, 0.0),
+            ],
+            schema=StructType([
+                StructField('id', IntegerType(), False),
+                StructField('age', IntegerType(), False),
+                StructField('income', FloatType(), False),
+                StructField('is_bad', FloatType(), False),
+            ])
+        )
+    )
+    return dataset
+
+
+@pytest.fixture
+def dataset6():
+    dataset = (
+        spark
+        .createDataFrame(
+            [
+                (1, 10, 1000, 0.1),
+                (2, 20, 2000, 0.2),
+                (3, 30, 3000, 0.3),
+                (4, 40, 4000, 0.4),
+                (5, 50, 5000, 0.5),
+                (6, 60, 6000, 0.6),
+                (7, 70, 7000, 0.7),
+                (8, 80, 8000, 0.8),
+                (9, 90, 9000, 0.9),
+                (10, 36, 10000, 1.0),
+            ],
+            schema=StructType([
+                StructField('id', IntegerType(), False),
+                StructField('age', IntegerType(), False),
+                StructField('income', IntegerType(), False),
+                StructField('is_bad', FloatType(), False),
+            ])
+        )
+    )
+    return dataset
+
+
+@pytest.mark.parametrize('dataset_fixture', ['dataset1', 'dataset2', 'dataset3', 'dataset4'])
+@pytest.mark.parametrize('order_value,expected_error', [
+    (-1, 'ge'),  # Error order must be greater than 0
+    (0, 'ge'),  # Error order must be greater than 0
+    (0.5, 'ie'),  # Error order must be integer
+    (1, 'no'),  # No error expected
+    (1.5, 'ie'),  # Error order must be integer
+    (2, 'no'),  # No error expected
+    (3, 'wr'),  # Expected warning memory issues
+    (4, 'wr'),  # Expected warning memory issues
+    (5, 'wr')  # Expected warning memory issues
+])
+def test_get_neighbors_order_warns(
+    dataset_fixture,
+    order_value,
+    expected_error,
+    request
+):
+    dataset = request.getfixturevalue(dataset_fixture)
+    if expected_error == 'ge':
+        with pytest.raises(AssertionError, match='order must be an integer greater than 0.'):
+            get_neighbors(dataset, order=order_value)
+    elif expected_error == 'ie':
+        with pytest.raises(AssertionError, match='order must be an integer.'):
+            get_neighbors(dataset, order=order_value)
+    elif expected_error == 'wr':
+        with pytest.warns(UserWarning, match=f'order={order_value} may cause the process to be slow.'):
+            get_neighbors(dataset, order=order_value)
+    else:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            get_neighbors(dataset, order=order_value)
+        assert len(w) == 0
+
+
+@pytest.mark.parametrize('dataset_fixture_edges', ['dataset1', 'dataset2', 'dataset3', 'dataset4'])
+@pytest.mark.parametrize('dataset_fixture_vertices', ['dataset5', 'dataset6'])
+@pytest.mark.parametrize('attributes,expected_error', [
+    (5, 'lse'),  # Error attributes must be a list of strings
+    ([5, 'age'], 'aise'),  # Error all items in attributes must be strings
+    (['age', 'income', 'other'], 'aiee'),  # Error all items in attributes must exist in vertices
+    (['age', 'income', 'is_bad'], 'no'),  # No error expected
+])
+def test_aggregate_messages_attr_warns(
+    dataset_fixture_edges,
+    dataset_fixture_vertices,
+    attributes,
+    expected_error,
+    request
+):
+    edges = request.getfixturevalue(dataset_fixture_edges)
+    vertices = request.getfixturevalue(dataset_fixture_vertices)
+    if expected_error == 'lse':
+        with pytest.raises(AssertionError, match='attributes must be a list of strings.'):
+            aggregate_messages(edges, vertices, attributes=attributes)
+    elif expected_error == 'aise':
+        with pytest.raises(AssertionError, match='All items in attributes must be strings.'):
+            aggregate_messages(edges, vertices, attributes=attributes)
+    elif expected_error == 'aiee':
+        with pytest.raises(AssertionError, match='All items in attributes must exist in vertices.'):
+            aggregate_messages(edges, vertices, attributes=attributes)
+    else:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            aggregate_messages(edges, vertices, attributes=attributes)
+        assert len(w) == 0
+
+
+@pytest.mark.parametrize('dataset_fixture_edges', ['dataset1', 'dataset2', 'dataset3', 'dataset4'])
+@pytest.mark.parametrize('dataset_fixture_vertices', ['dataset5', 'dataset6'])
+@pytest.mark.parametrize('functions,expected_error', [
+    ('mode', 'yes'),  # Error invalid aggregate function
+    (['sum', 'avg', 'min'], 'no'),  # No error expected
+])
+def test_aggregate_messages_aggf_warns(
+    dataset_fixture_edges,
+    dataset_fixture_vertices,
+    functions,
+    expected_error,
+    request
+):
+    edges = request.getfixturevalue(dataset_fixture_edges)
+    vertices = request.getfixturevalue(dataset_fixture_vertices)
+    msg = 'Invalid aggregation function. Please provide one or more of ' \
+        'the following valid options: "sum", "min", "max", "avg" or "wavg".'
+    if expected_error == 'yes':
+        with pytest.raises(AssertionError, match=msg):
+            aggregate_messages(edges, vertices, agg_funcs=functions)
+    else:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            aggregate_messages(edges, vertices, agg_funcs=functions)
+        assert len(w) == 0

--- a/unit_tests/test_graph_features.py
+++ b/unit_tests/test_graph_features.py
@@ -53,7 +53,7 @@ def test_verify_vertices_non_numeric_error():
 
 
 # _verify_edges (expected to pass)
-def test_verify_edges_success():
+def test_verify_vertices_success():
     try:
         gf._verify_vertices(v.select("id", "x3"))
     except AssertionError:
@@ -98,8 +98,8 @@ def test_verify_edges_directed_graph():
         gf._verify_edges(
             e.unionByName(
                 e.select(F.col("dst").alias("src"), F.col("src").alias("dst"))
+            )
         )
-    )
 
 
 # _verify_edges (expected to pass)
@@ -108,6 +108,7 @@ def test_verify_edges_success():
         gf._verify_edges(e)
     except AssertionError:
         pytest.fail("Valid edges raised an unexpected AssertionError.")
+
 
 @pytest.fixture
 def dataset1():
@@ -265,7 +266,10 @@ def dataset6():
     return dataset
 
 
-@pytest.mark.parametrize('dataset_fixture', ['dataset1', 'dataset2', 'dataset3', 'dataset4'])
+@pytest.mark.parametrize(
+    'dataset_fixture',
+    ['dataset1', 'dataset2', 'dataset3', 'dataset4']
+)
 @pytest.mark.parametrize('order_value,expected_error', [
     (-1, 'ge'),  # Error order must be greater than 0
     (0, 'ge'),  # Error order must be greater than 0
@@ -285,13 +289,19 @@ def test_get_neighbors_order_warns(
 ):
     dataset = request.getfixturevalue(dataset_fixture)
     if expected_error == 'ge':
-        with pytest.raises(AssertionError, match='order must be an integer greater than 0.'):
+        with pytest.raises(
+            AssertionError,
+            match='order must be an integer greater than 0.'
+        ):
             get_neighbors(dataset, order=order_value)
     elif expected_error == 'ie':
         with pytest.raises(AssertionError, match='order must be an integer.'):
             get_neighbors(dataset, order=order_value)
     elif expected_error == 'wr':
-        with pytest.warns(UserWarning, match=f'order={order_value} may cause the process to be slow.'):
+        with pytest.warns(
+            UserWarning,
+            match=f'order={order_value} may cause the process to be slow.'
+        ):
             get_neighbors(dataset, order=order_value)
     else:
         with warnings.catch_warnings(record=True) as w:
@@ -300,12 +310,15 @@ def test_get_neighbors_order_warns(
         assert len(w) == 0
 
 
-@pytest.mark.parametrize('dataset_fixture_edges', ['dataset1', 'dataset2', 'dataset3', 'dataset4'])
+@pytest.mark.parametrize(
+    'dataset_fixture_edges',
+    ['dataset1', 'dataset2', 'dataset3', 'dataset4']
+)
 @pytest.mark.parametrize('dataset_fixture_vertices', ['dataset5', 'dataset6'])
 @pytest.mark.parametrize('attributes,expected_error', [
     (5, 'lse'),  # Error attributes must be a list of strings
     ([5, 'age'], 'aise'),  # Error all items in attributes must be strings
-    (['age', 'income', 'other'], 'aiee'),  # Error all items in attributes must exist in vertices
+    (['age', 'income', 'other'], 'aiee'),  # All items in attrs must exist in vertices
     (['age', 'income', 'is_bad'], 'no'),  # No error expected
 ])
 def test_aggregate_messages_attr_warns(
@@ -318,13 +331,22 @@ def test_aggregate_messages_attr_warns(
     edges = request.getfixturevalue(dataset_fixture_edges)
     vertices = request.getfixturevalue(dataset_fixture_vertices)
     if expected_error == 'lse':
-        with pytest.raises(AssertionError, match='attributes must be a list of strings.'):
+        with pytest.raises(
+            AssertionError,
+            match='attributes must be a list of strings.'
+        ):
             aggregate_messages(edges, vertices, attributes=attributes)
     elif expected_error == 'aise':
-        with pytest.raises(AssertionError, match='All items in attributes must be strings.'):
+        with pytest.raises(
+            AssertionError,
+            match='All items in attributes must be strings.'
+        ):
             aggregate_messages(edges, vertices, attributes=attributes)
     elif expected_error == 'aiee':
-        with pytest.raises(AssertionError, match='All items in attributes must exist in vertices.'):
+        with pytest.raises(
+            AssertionError,
+            match='All items in attributes must exist in vertices.'
+        ):
             aggregate_messages(edges, vertices, attributes=attributes)
     else:
         with warnings.catch_warnings(record=True) as w:
@@ -333,7 +355,10 @@ def test_aggregate_messages_attr_warns(
         assert len(w) == 0
 
 
-@pytest.mark.parametrize('dataset_fixture_edges', ['dataset1', 'dataset2', 'dataset3', 'dataset4'])
+@pytest.mark.parametrize(
+    'dataset_fixture_edges',
+    ['dataset1', 'dataset2', 'dataset3', 'dataset4']
+)
 @pytest.mark.parametrize('dataset_fixture_vertices', ['dataset5', 'dataset6'])
 @pytest.mark.parametrize('functions,expected_error', [
     ('mode', 'yes'),  # Error invalid aggregate function

--- a/unit_tests/test_graph_features.py
+++ b/unit_tests/test_graph_features.py
@@ -407,8 +407,10 @@ def test_aggregate_messages_aggf_warns(
             "weight": "weight",
             }
         )
-    msg = 'Invalid aggregation function. Please provide one or more of ' \
+    msg = (
+        'Invalid aggregation function. Please provide one or more of '
         'the following valid options: "sum", "min", "max", "avg" or "wavg".'
+    )
     if expected_error == 'yes':
         with pytest.raises(AssertionError, match=msg):
             gf = GraphFeatures(agg_funcs=functions)


### PR DESCRIPTION
We added a new module `graph_features.py` in `mercury/graph/ml/`. This module defines a new class `GraphFeatures` (compliant with the new API standards) that lets users generate graph-based features.

For example:
```
# Init mercury graph
g = Graph(data=edges, nodes=vertices, keys={"directed": False})

# Init GraphFeatures instance
gf = GraphFeatures(
    attributes=["feature1", "feature2"],  # Valid names in `vertices`
    agg_funcs=["min", "max", "avg"]
)

# Fit instance
gf.fit(g)  # Adds `node_features_` attribute to `gf`

# Show results
gf.node_features_.show(5)  # Display new graph features
```

You can find an [interactive example here](https://colab.research.google.com/drive/1s9S-Rng5R3v6RZmMPp3OWrKVBGQUQhoq?usp=sharing).

---
Coauthored by @GasparGarciaBaez, @mikegrados and @ArturoSbr 